### PR TITLE
Fixes YAC35,37,39

### DIFF
--- a/make_training_data_from_sketches.py
+++ b/make_training_data_from_sketches.py
@@ -39,7 +39,8 @@ if __name__ == "__main__":
         signatures = signatures[:N]
 
     # check that all signatures have the same ksize as the one provided
-    # signatures_mismatch_ksize return False (if all signatures have the same kmer size) or True (the first signature with a different kmer size)
+    # signatures_mismatch_ksize return False (if all signatures have the same kmer size)
+    # or True (the first signature with a different kmer size)
     if utils.signatures_mismatch_ksize(signatures, ksize):
         raise ValueError(f"Not all signatures from sourmash signature file {ref_file} have the given ksize {ksize}")
 

--- a/make_training_data_from_sketches.py
+++ b/make_training_data_from_sketches.py
@@ -1,126 +1,12 @@
 #!/usr/bin/env python
-import os, sys
-import numpy as np
+import sys
 import sourmash
-import csv
 import argparse
-from scipy.sparse import csc_matrix, save_npz
+from scipy.sparse import save_npz
 import srcs.utils as utils
-import pickle
-from tqdm import tqdm
 from loguru import logger
 logger.remove()
-logger.add(sys.stdout, format="{time:YYYY-MM-DD HH:mm:ss} - {level} - {message}", level="INFO");
-
-def signatures_to_ref_matrix(signatures):
-    """
-    Given a list of signatures, return a sparse matrix with one column per signature and one row per hash
-    (union of the hashes)
-    :param signatures: list of signatures obtained via sourmash.load_file_as_signatures(<file name>)
-    :return:
-    ref_matrix: sparse matrix with one column per signature and one row per hash (union of the hashes)
-    hash_to_idx: dictionary mapping hash to row index in ref_matrix
-    """
-    row_idx = []
-    col_idx = []
-    sig_values = []
-    
-    # Use a dictionary to store hash to index mapping
-    hash_to_idx = {}
-    next_idx = 0  # Next available index for a new hash
-    
-    # Iterate over all signatures
-    for col, sig in enumerate(tqdm(signatures)):
-        sig_hashes = sig.minhash.hashes
-        for hash, count in sig_hashes.items():
-            # Get the index for this hash， if new hash, and it and increment next_idx
-            idx = hash_to_idx.setdefault(hash, next_idx)
-            if idx == next_idx:  # New hash was added
-                next_idx += 1
-
-            # Append row, col, and value information for creating the sparse matrix
-            row_idx.append(idx)
-            col_idx.append(col)
-            sig_values.append(count)
-
-    ref_matrix = csc_matrix((sig_values, (row_idx, col_idx)), shape=(next_idx, len(signatures)))
-
-    return ref_matrix, hash_to_idx
-
-
-def get_uncorr_ref(ref_matrix, ksize, ani_thresh):
-    """
-    Given a reference matrix, return a new reference matrix with only uncorrelated organisms
-    :param ref_matrix: sparse matrix with one column per signature and one row per hash (union of the hashes)
-    :param ksize: int, size of kmer
-    :param ani_thresh: threshold for mutation rate, below which we consider two organisms to be correlated/the same
-    :return:
-    binary_ref: a new reference matrix with only uncorrelated organisms in binary form (discarding counts)
-    uncorr_idx: the indices of the organisms in the reference matrix that are uncorrelated/distinct
-    """
-
-    N = ref_matrix.shape[1]  # number of organisms
-    immut_prob = ani_thresh ** ksize  # probability of immutation
-    
-    # Convert the input matrix to a binary matrix
-    # since I don't think we are actually using the counts anywhere, we could probably get a performance
-    # boost by just using a binary matrix to begin with
-    binary_ref = (ref_matrix > 0).astype(int)
-    # number of hashes in each organism
-    sizes = np.array(np.sum(binary_ref, axis=0)).reshape(N)
-    
-    # sort organisms by size  in ascending order, so we keep the largest organism, discard the smallest
-    bysize = np.argsort(sizes)
-    # binary_ref sorted by size
-    binary_ref_bysize = binary_ref[:, bysize]
-    
-    # Compute all pairwise intersections
-    intersections = binary_ref_bysize.T.dot(binary_ref_bysize)
-    # set diagonal to 0, since we don't want to compare an organism to itself
-    intersections.setdiag(0)
-    
-    uncorr_idx_bysize = np.arange(N)
-    immut_prob_sizes = immut_prob * sizes[bysize]
-    
-    for i in range(N):        
-        # Remove organisms if they are too similar 
-        # (Note that we remove organism if there is at least one other organism with intersection > immut_prob_sizes[i])
-        if np.max(intersections[i, uncorr_idx_bysize]) > immut_prob_sizes[i]:
-            uncorr_idx_bysize = np.setdiff1d(uncorr_idx_bysize, i)
-
-    # Sort the remaining indices, uncorr_idx is now the indices of the organisms in the reference matrix that are uncorrelated
-    uncorr_idx = np.sort(bysize[uncorr_idx_bysize])
-
-    return binary_ref[:, uncorr_idx], uncorr_idx
-
-
-def write_hashes(filename, hashes):
-    """
-    Write a csv file with the following columns: hash, index
-    :param filename: output filename
-    :param hashes: dictionary mapping hash to index
-    :return: None
-    """
-    with open(filename, 'wb') as fid:
-        pickle.dump(hashes, fid)
-
-
-def write_processed_indices(filename, signatures, uncorr_org_idx):
-    """
-    Write a csv file with the following columns: organism_name, original_index, processed_index,
-    num_unique_kmers_in_genome_sketch, num_total_kmers_in_genome_sketch, genome_scale_factor.
-    :param filename: output filename
-    :param signatures: sourmash signatures
-    :param uncorr_org_idx: the indices of the organisms in the reference matrix that are uncorrelated
-    (via get_uncorr_ref)
-    :return: None
-    """
-    with open(filename, 'w', newline='', encoding='utf-8') as f:
-        writer = csv.writer(f)
-        writer.writerow(['organism_name', 'original_index', 'processed_index', 'num_unique_kmers_in_genome_sketch', 'num_total_kmers_in_genome_sketch', 'genome_scale_factor'])
-        for i, idx in enumerate(tqdm(uncorr_org_idx)):
-            writer.writerow([signatures[idx].name, idx, i, len(signatures[idx].minhash.hashes), utils.get_num_kmers(signatures[idx], scale=False), signatures[idx].minhash.scaled])
-
+logger.add(sys.stdout, format="{time:YYYY-MM-DD HH:mm:ss} - {level} - {message}", level="INFO")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -159,17 +45,17 @@ if __name__ == "__main__":
 
     # convert signatures to reference matrix (rows are hashes/kmers, columns are organisms)
     logger.info("Converting signatures to reference matrix")
-    ref_matrix, hashes = signatures_to_ref_matrix(signatures)
+    ref_matrix, hashes = utils.signatures_to_ref_matrix(signatures)
 
     # remove 'same' organisms: any organisms with ANI > ani_thresh are considered the same organism
     logger.info("Removing 'same' organisms with ANI > ani_thresh")
-    processed_ref_matrix, uncorr_org_idx = get_uncorr_ref(ref_matrix, ksize, ani_thresh)
+    processed_ref_matrix, uncorr_org_idx = utils.get_uncorr_ref(ref_matrix, ksize, ani_thresh)
     save_npz(f'{out_prefix}_ref_matrix_processed.npz', processed_ref_matrix)
 
     # write out hash-to-row-indices file
     logger.info("Writing out hash-to-row-indices file")
-    write_hashes(f'{out_prefix}_hash_to_col_idx.pkl', hashes)
+    utils.write_hashes(f'{out_prefix}_hash_to_col_idx.pkl', hashes)
 
     # write out organism manifest (original index, processed index, num unique kmers, num total kmers, scale factor)
     logger.info("Writing out organism manifest")
-    write_processed_indices(f'{out_prefix}_processed_org_idx.csv', signatures, uncorr_org_idx)
+    utils.write_processed_indices(f'{out_prefix}_processed_org_idx.csv', signatures, uncorr_org_idx)

--- a/srcs/utils.py
+++ b/srcs/utils.py
@@ -9,7 +9,7 @@ import csv
 
 def load_hashes(filename):
     """
-    Helper function that loads the hash_to_col_idx.csv file and returns a dictionary mapping hashes to indices in the
+    Helper function that loads the hash_to_col_idx.pkl file and returns a dictionary mapping hashes to indices in the
     training dictionary. filename should point to a CSV file with two columns: hash, col_idx.
     :param filename: string (location of the hash_to_col_idx.pkl file)
     :return: dictionary mapping hashes to indicies
@@ -21,7 +21,8 @@ def load_hashes(filename):
     
 def load_signature_with_ksize(filename, ksize):
     """
-    Helper function that loads the signature for a given kmer size from the provided signature file. Filename should point to a .sig file. Raises exception if given kmer size is not present in the file.
+    Helper function that loads the signature for a given kmer size from the provided signature file.
+    Filename should point to a .sig file. Raises exception if given kmer size is not present in the file.
     :param filename: string (location of the signature file)
     :param ksize: kmer size
     :return: sourmash signature

--- a/srcs/utils.py
+++ b/srcs/utils.py
@@ -3,6 +3,8 @@ import numpy as np
 import pickle
 import sourmash
 from tqdm import tqdm
+from scipy.sparse import csc_matrix, save_npz
+import csv
 
 
 def load_hashes(filename):
@@ -89,3 +91,113 @@ def compute_sample_vector(sample_hashes, hash_to_idx):
         sample_vector[hash_to_idx[sh]] = sample_hashes[sh]
 
     return sample_vector
+
+
+def signatures_to_ref_matrix(signatures):
+    """
+    Given a list of signatures, return a sparse matrix with one column per signature and one row per hash
+    (union of the hashes)
+    :param signatures: list of signatures obtained via sourmash.load_file_as_signatures(<file name>)
+    :return:
+    ref_matrix: sparse matrix with one column per signature and one row per hash (union of the hashes)
+    hash_to_idx: dictionary mapping hash to row index in ref_matrix
+    """
+    row_idx = []
+    col_idx = []
+    sig_values = []
+
+    # Use a dictionary to store hash to index mapping
+    hash_to_idx = {}
+    next_idx = 0  # Next available index for a new hash
+
+    # Iterate over all signatures
+    for col, sig in enumerate(tqdm(signatures)):
+        sig_hashes = sig.minhash.hashes
+        for hash, count in sig_hashes.items():
+            # Get the index for this hash， if new hash, and it and increment next_idx
+            idx = hash_to_idx.setdefault(hash, next_idx)
+            if idx == next_idx:  # New hash was added
+                next_idx += 1
+
+            # Append row, col, and value information for creating the sparse matrix
+            row_idx.append(idx)
+            col_idx.append(col)
+            sig_values.append(count)
+
+    ref_matrix = csc_matrix((sig_values, (row_idx, col_idx)), shape=(next_idx, len(signatures)))
+
+    return ref_matrix, hash_to_idx
+
+
+def get_uncorr_ref(ref_matrix, ksize, ani_thresh):
+    """
+    Given a reference matrix, return a new reference matrix with only uncorrelated organisms
+    :param ref_matrix: sparse matrix with one column per signature and one row per hash (union of the hashes)
+    :param ksize: int, size of kmer
+    :param ani_thresh: threshold for mutation rate, below which we consider two organisms to be correlated/the same
+    :return:
+    binary_ref: a new reference matrix with only uncorrelated organisms in binary form (discarding counts)
+    uncorr_idx: the indices of the organisms in the reference matrix that are uncorrelated/distinct
+    """
+
+    N = ref_matrix.shape[1]  # number of organisms
+    immut_prob = ani_thresh ** ksize  # probability of immutation
+
+    # Convert the input matrix to a binary matrix
+    # since I don't think we are actually using the counts anywhere, we could probably get a performance
+    # boost by just using a binary matrix to begin with
+    binary_ref = (ref_matrix > 0).astype(int)
+    # number of hashes in each organism
+    sizes = np.array(np.sum(binary_ref, axis=0)).reshape(N)
+
+    # sort organisms by size  in ascending order, so we keep the largest organism, discard the smallest
+    bysize = np.argsort(sizes)
+    # binary_ref sorted by size
+    binary_ref_bysize = binary_ref[:, bysize]
+
+    # Compute all pairwise intersections
+    intersections = binary_ref_bysize.T.dot(binary_ref_bysize)
+    # set diagonal to 0, since we don't want to compare an organism to itself
+    intersections.setdiag(0)
+
+    uncorr_idx_bysize = np.arange(N)
+    immut_prob_sizes = immut_prob * sizes[bysize]
+
+    for i in range(N):
+        # Remove organisms if they are too similar
+        # (Note that we remove organism if there is at least one other organism with intersection > immut_prob_sizes[i])
+        if np.max(intersections[i, uncorr_idx_bysize]) > immut_prob_sizes[i]:
+            uncorr_idx_bysize = np.setdiff1d(uncorr_idx_bysize, i)
+
+    # Sort the remaining indices, uncorr_idx is now the indices of the organisms in the reference matrix that are uncorrelated
+    uncorr_idx = np.sort(bysize[uncorr_idx_bysize])
+
+    return binary_ref[:, uncorr_idx], uncorr_idx
+
+
+def write_hashes(filename, hashes):
+    """
+    Write a csv file with the following columns: hash, index
+    :param filename: output filename
+    :param hashes: dictionary mapping hash to index
+    :return: None
+    """
+    with open(filename, 'wb') as fid:
+        pickle.dump(hashes, fid)
+
+
+def write_processed_indices(filename, signatures, uncorr_org_idx):
+    """
+    Write a csv file with the following columns: organism_name, original_index, processed_index,
+    num_unique_kmers_in_genome_sketch, num_total_kmers_in_genome_sketch, genome_scale_factor.
+    :param filename: output filename
+    :param signatures: sourmash signatures
+    :param uncorr_org_idx: the indices of the organisms in the reference matrix that are uncorrelated
+    (via get_uncorr_ref)
+    :return: None
+    """
+    with open(filename, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.writer(f)
+        writer.writerow(['organism_name', 'original_index', 'processed_index', 'num_unique_kmers_in_genome_sketch', 'num_total_kmers_in_genome_sketch', 'genome_scale_factor'])
+        for i, idx in enumerate(tqdm(uncorr_org_idx)):
+            writer.writerow([signatures[idx].name, idx, i, len(signatures[idx].minhash.hashes), get_num_kmers(signatures[idx], scale=False), signatures[idx].minhash.scaled])

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -16,9 +16,9 @@ def test_full_workflow():
     abundance_file = full_out_prefix + "recovered_abundance.csv"
     reference_sketches = os.path.join(data_dir, "20_genomes_sketches.zip")
     sample_sketches = os.path.join(data_dir, "sample.sig")
-    expected_files = map(lambda x: full_out_prefix + x, ["hash_to_col_idx.csv", "processed_org_idx.csv",
-                                              "ref_matrix_processed.npz", "ref_matrix_unprocessed.npz",
-                                              "recover_abundance.csv"])
+    expected_files = map(lambda x: full_out_prefix + x, ["_hash_to_col_idx.csv", "_processed_org_idx.csv",
+                                              "_ref_matrix_processed.npz", "_ref_matrix_unprocessed.npz",
+                                              "_recover_abundance.csv", "_ksize_ani_thresh.json"])
     # remove the files if they exist
     for f in expected_files:
         if exists(f):
@@ -38,9 +38,9 @@ def test_full_workflow():
     # then do the abundance estimation
     if exists(abundance_file):
         os.remove(abundance_file)
-    cmd = f"python {os.path.join(script_dir, 'run_YACHT.py')} --ref_matrix " \
-          f"{full_out_prefix}_ref_matrix_processed.npz --sample_file " \
-          f"{sample_sketches} --outfile {abundance_file} --ksize 31"
+    cmd = f"python {os.path.join(script_dir, 'run_YACHT.py')} --database_prefix " \
+          f"{full_out_prefix} --sample_file " \
+          f"{sample_sketches} --outfile {abundance_file}"
     #print(cmd)
     res = subprocess.run(cmd, shell=True, check=True)
     # check that no errors were raised

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -23,8 +23,8 @@ def test_full_workflow():
     for f in expected_files:
         if exists(f):
             os.remove(f)
-    cmd = f"python {os.path.join(script_dir, 'make_training_data_from_sketches.py')} --ref_file {reference_sketches} --out_prefix" \
-          f" {full_out_prefix} --ksize 31"
+    cmd = f"python {os.path.join(script_dir, 'make_training_data_from_sketches.py')} --ref_file {reference_sketches}" \
+          f" --out_prefix {full_out_prefix} --ksize 31"
     res = subprocess.run(cmd, shell=True, check=True)
     # check that no errors were raised
     assert res.returncode == 0
@@ -38,7 +38,8 @@ def test_full_workflow():
     # then do the abundance estimation
     if exists(abundance_file):
         os.remove(abundance_file)
-    cmd = f"python {os.path.join(script_dir, 'run_YACHT.py')} --ref_matrix {full_out_prefix}_ref_matrix_processed.npz --sample_file " \
+    cmd = f"python {os.path.join(script_dir, 'run_YACHT.py')} --ref_matrix " \
+          f"{full_out_prefix}_ref_matrix_processed.npz --sample_file " \
           f"{sample_sketches} --outfile {abundance_file} --ksize 31"
     #print(cmd)
     res = subprocess.run(cmd, shell=True, check=True)

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -11,7 +11,7 @@ def test_full_workflow():
     """
     script_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))  # currently one level above ./tests
     data_dir = "testdata"
-    out_prefix = "unittest_"
+    out_prefix = "integration_test"
     full_out_prefix = os.path.join(data_dir, out_prefix)
     abundance_file = full_out_prefix + "recovered_abundance.csv"
     reference_sketches = os.path.join(data_dir, "20_genomes_sketches.zip")
@@ -38,7 +38,7 @@ def test_full_workflow():
     # then do the abundance estimation
     if exists(abundance_file):
         os.remove(abundance_file)
-    cmd = f"python {os.path.join(script_dir, 'run_YACHT.py')} --ref_matrix {full_out_prefix}ref_matrix_processed.npz --sample_file " \
+    cmd = f"python {os.path.join(script_dir, 'run_YACHT.py')} --ref_matrix {full_out_prefix}_ref_matrix_processed.npz --sample_file " \
           f"{sample_sketches} --outfile {abundance_file} --ksize 31"
     #print(cmd)
     res = subprocess.run(cmd, shell=True, check=True)


### PR DESCRIPTION
- still writes the various training files to disk, but now the user needs only input and use the prefix instead of keeping track of how the npz matrix is named
- removes the `--N` parameter that was used for de-buging
- makes a new json file that stores the k-mer size and ani_thresh, removes these parameters from `run_YACHT.py` as they must/should always match the ones used in `make_training_data_from_sketches.py`
- Changes default coverage to 0.01
- Fix integration test to reflect these changes

Note: these are breaking changes and not backward compatible due to script parameter changes and default setting changes