### PR TITLE
fix a potential bug

### DIFF
--- a/srcs/utils.py
+++ b/srcs/utils.py
@@ -88,13 +88,16 @@ def compute_sample_vector(sample_hashes, hash_to_idx):
     :return: numpy array (sample vector)
     """
     # total number of hashes in the training dictionary
-    hash_to_idx_keys = list(hash_to_idx.keys())
+    hash_to_idx_keys = set(hash_to_idx.keys())
+    
+    # total number of hashes in the sample
+    sample_hashes_keys = set(sample_hashes.keys())
     
     # initialize the sample vector
     sample_vector = np.zeros(len(hash_to_idx_keys))
     
     # get the hashes that are in both the sample and the training dictionary
-    sample_intersect_training_hashes = np.intersect1d(sample_hashes, hash_to_idx_keys,  assume_unique=True)
+    sample_intersect_training_hashes = hash_to_idx_keys.intersection(sample_hashes_keys)
     
     # fill in the sample vector
     for sh in tqdm(sample_intersect_training_hashes):


### PR DESCRIPTION
Hi @dkoslicki, please take a look at this change to see if my changes make sense to you.

It seems like there is a potential bug in your code using `np.intersect1d` to find the shared hashes between sample and the training dictionary. [This](https://github.com/KoslickiLab/YACHT/blob/675715cdf99d2af5649fbbe5fa219c938b955888/srcs/utils.py#L97) line returns a float value instead of integer value which may cause an error:

```
Traceback (most recent call last):
  File "~/YACHT-reproducibles/YACHT/run_YACHT.py", line 84, in <module>
    sample_vector = utils.compute_sample_vector(sample_hashes, hash_to_idx)
  File "~/YACHT-reproducibles/YACHT/srcs/utils.py", line 101, in compute_sample_vector
    sample_vector[hash_to_idx[sh]] = sample_hashes[sh]
  File "~/miniconda3/envs/yacht/lib/python3.10/site-packages/sourmash/minhash.py", line 145, in __getitem__
    return self._data[key]
KeyError: 9048445695619516.0
```

I'm not sure if it depends on the numpy version. I didn't get error before but in my recent run, it has this error. It is not stable and may have a potential error. So I utilized the set intersection to find the common hashes.
