### PR TITLE
bug YAC-98 accepts .sig file now

### DIFF
--- a/yacht/make_training_data_from_sketches.py
+++ b/yacht/make_training_data_from_sketches.py
@@ -38,11 +38,11 @@ def main(args):
 
     # make sure reference database file exist and valid
     logger.info("Checking reference database file")
-    if os.path.splitext(ref_file)[1] != '.zip':
+    if os.path.splitext(ref_file)[1] != '.zip' and os.path.splitext(ref_file)[1] != '.sig':
         raise ValueError(
-            f"Reference database file {ref_file} is not a zip file. Please a Sourmash signature database file with Zipfile format.")
+            f"Reference database file {ref_file} is not a sig.zip or a .sig file. Please use a Sourmash signature database file in correct signature format.")
     utils.check_file_existence(str(Path(ref_file).absolute()),
-                               f'Reference database zip file {ref_file} does not exist.')
+                               f'Reference database signature file {ref_file} does not exist.')
 
     # Create a temporary directory with time info as label
     logger.info("Creating a temporary directory")

--- a/yacht/make_training_data_from_sketches.py
+++ b/yacht/make_training_data_from_sketches.py
@@ -38,9 +38,10 @@ def main(args):
 
     # make sure reference database file exist and valid
     logger.info("Checking reference database file")
-    if os.path.splitext(ref_file)[1] != '.zip' and os.path.splitext(ref_file)[1] != '.sig':
+    print(os.path.splitext(ref_file)[1])
+    if os.path.splitext(ref_file)[1] not in ['.zip', '.sig', '.sbt' ,'.sqldb', '.lca']:
         raise ValueError(
-            f"Reference database file {ref_file} is not a sig.zip or a .sig file. Please use a Sourmash signature database file in correct signature format.")
+            f"Reference database file {ref_file} is not a valid file format. Please use a Sourmash signature database file format: \".sig.zip\", \".sig\", \".sbt\", \".sqldb\", or \".lca\".")
     utils.check_file_existence(str(Path(ref_file).absolute()),
                                f'Reference database signature file {ref_file} does not exist.')
 
@@ -57,9 +58,10 @@ def main(args):
     os.makedirs(path_to_temp_dir, exist_ok=True)
 
     # unzip the sourmash signature file to the temporary directory
-    logger.info("Unzipping the sourmash signature file to the temporary directory")
-    with zipfile.ZipFile(ref_file, 'r') as sourmash_db:
-        sourmash_db.extractall(path_to_temp_dir)
+    if os.path.splitext(ref_file)[1] == '.zip':
+        logger.info("Unzipping the sourmash signature file to the temporary directory")
+        with zipfile.ZipFile(ref_file, 'r') as sourmash_db:
+            sourmash_db.extractall(path_to_temp_dir)
 
     # Extract signature information
     logger.info("Extracting signature information")


### PR DESCRIPTION
I was able to reproduce this error and fixed the condition on the type of file that is being accepted, so now a .sig.zip and .sig files can be accepted.

However, now I get the following error where the file will be extracted so a zipfile is expected.

Is this necessary in YACHT? Unsure how to move on from here.

```
2024-01-13 13:10:26 - INFO - Checking reference database file
2024-01-13 13:10:26 - INFO - Creating a temporary directory
2024-01-13 13:10:26 - INFO - Unzipping the sourmash signature file to the temporary directory
Traceback (most recent call last):
  File "/home/grads/jzr5814/miniconda3/envs/yacht_env/bin/yacht", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/data/jzr5814/repositories/YACHT/yacht/__init__.py", line 51, in main
    args.func(args)
  File "/data/jzr5814/repositories/YACHT/yacht/make_training_data_from_sketches.py", line 61, in main
    with zipfile.ZipFile(ref_file, 'r') as sourmash_db:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/grads/jzr5814/miniconda3/envs/yacht_env/lib/python3.12/zipfile/__init__.py", line 1338, in __init__
    self._RealGetContents()
  File "/home/grads/jzr5814/miniconda3/envs/yacht_env/lib/python3.12/zipfile/__init__.py", line 1405, in _RealGetContents
    raise BadZipFile("File is not a zip file")
zipfile.BadZipFile: File is not a zip file
```