### PR TITLE
Add Contributing Guideline file

### DIFF
--- a/CONTRIBUTING_GUIDELINE.md
+++ b/CONTRIBUTING_GUIDELINE.md
@@ -1,0 +1,39 @@
+# Contributing Guidelines
+
+## How to Contribute to YACHT
+
+We welcome all contributions! Here's how you can help:
+
+* Report bugs or reequests features via [Issues](https://github.com/KoslickiLab/YACHT/issues)
+* Improve the documentation or write tutorials (e.g. usage case examples)
+* Submit code improvements via Pull Requests
+
+## Issue Submission
+
+### Bug Reports
+Include:
+* Clear description of the issue
+* Provide minimal reproducible example
+* YACHT version number
+* Expected vs. actual behavior
+
+### Feature Requests
+Include:
+* Description of the proposed feature
+* Use case/benefit explanation
+* Implementation ideas (optional)
+
+### Pull Requests
+* Fork the repo and create a feature branch
+* Write clear commit messages
+* Add tests for new functionality
+* Update documentation if needed
+* Ensure all tests pass before submission
+
+### Code Style
+* Follow existing code conventions
+* Include docstrings for new functions
+* Keep changes focused and atomic
+
+## Questions?
+Open an issue for discussion or reach out to maintainers.


### PR DESCRIPTION
For JOSS paper requirement. Following the practices of recent authors; they placed the Contributing Guideline at the root level of the repo.